### PR TITLE
Add the case for also handling new line as delimiter

### DIFF
--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -1,5 +1,7 @@
 # class decalartion for the String calculator
 class StringCalculator
+    # regex supporting , and newline as delimiters
+    DEFAULT_DELIMITERS = /,|\n/
     # Adds numbers present in a string and returns the sum
     def add(numbers)
         # returns 0 if the input string is empty or no input passed
@@ -7,10 +9,10 @@ class StringCalculator
         # return the number itself if only a single number
         return numbers.to_i unless numbers.include?(",")
 
-        # split the string by comma and sum the numbers
+        # split the string by comma or new line and sum the numbers
         # @input is a string e.g. "1,2,3"
-        # split will split the strings based on , delimitator and then map will return an array of integers
+        # split will split the strings based on delimitator and then map will return an array of integers
         # sum will return the sum of array elements
-        numbers.split(",").map(&:to_i).sum
+        numbers.split(DEFAULT_DELIMITERS).map(&:to_i).sum
     end
 end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -22,4 +22,8 @@ describe StringCalculator do
     it 'returns the sum of multiple numbers seperated by comma' do
         expect(calc.add("1,2,3,4")).to eq(10)
     end
+
+    it 'returns the sum of numbers seperated by newline' do
+        expect(calc.add("1\n2,3")).to eq(6)
+    end
 end


### PR DESCRIPTION
## 📝 Description

This PR further extends the functionality wherein apart from , now newline will also be supported as a delimiter.


## ✅ Changes
Input: '1\n2'
Output: 3


## 🧪 Testing
`rspec string_calculator_spec.rb`
```
Finished in 0.00424 seconds (files took 0.07026 seconds to load)
6 examples, 0 failures

```
