### PR TITLE
Add the case to handle custom delimiter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 source "https://rubygems.org"
 
 gem "rspec"
+gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.3)
     diff-lcs (1.6.2)
+    method_source (1.1.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -21,6 +26,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  pry
   rspec
 
 BUNDLED WITH

--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -1,18 +1,25 @@
 # class decalartion for the String calculator
 class StringCalculator
-    # regex supporting , and newline as delimiters
-    DEFAULT_DELIMITERS = /,|\n/
+    # array mentioning default delimiters
+    DEFAULT_DELIMITERS = [",", "\n"]
     # Adds numbers present in a string and returns the sum
     def add(numbers)
         # returns 0 if the input string is empty or no input passed
         return 0 if numbers.nil? || numbers == ""
-        # return the number itself if only a single number
-        return numbers.to_i unless numbers.include?(",")
 
         # split the string by comma or new line and sum the numbers
         # @input is a string e.g. "1,2,3"
         # split will split the strings based on delimitator and then map will return an array of integers
         # sum will return the sum of array elements
-        numbers.split(DEFAULT_DELIMITERS).map(&:to_i).sum
+
+        delimiters = DEFAULT_DELIMITERS.dup
+        # as the rule mentions to change a delimiter begining will contain a seperate line
+        if numbers.start_with?("//")
+            header, numbers = numbers.split("\n", 2)
+            delimiters << header[2]
+        end
+        # convert the array of delimiters into regex
+        regex = Regexp.union(delimiters)
+        numbers.split(regex).map(&:to_i).sum
     end
 end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -26,4 +26,8 @@ describe StringCalculator do
     it 'returns the sum of numbers seperated by newline' do
         expect(calc.add("1\n2,3")).to eq(6)
     end
+
+    it 'returns the sum of numbers seperated by single custom delimiter' do
+        expect(calc.add("//;\n1;2")).to eq(3)
+    end
 end


### PR DESCRIPTION
## 📝 Description
This PR further extends the add function to handle custom delimiters started with // as first line

## ✅ Changes
Input: "//;1\n2;3"
Output:"6

## 🧪 Testing
`rspec string_calculator_spec.rb`
```
Finished in 0.00415 seconds (files took 0.08516 seconds to load)
7 examples, 0 failures

```
## 📸 Screenshots (if applicable)
