### PR TITLE
Add Negative Numbers raise an exception check

### DIFF
--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -20,6 +20,12 @@ class StringCalculator
         end
         # convert the array of delimiters into regex
         regex = Regexp.union(delimiters)
-        numbers.split(regex).map(&:to_i).sum
+        nums = numbers.split(regex).map(&:to_i)
+
+        negatives = nums.select { |n| n < 0 }
+        # raise error if there are negative numbers 
+        raise "Negatives not allowed: #{negatives.join(', ')}" if negatives.any?
+
+        nums.sum
     end
 end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -30,4 +30,8 @@ describe StringCalculator do
     it 'returns the sum of numbers seperated by single custom delimiter' do
         expect(calc.add("//;\n1;2")).to eq(3)
     end
+
+    it 'raises an error if there are negatives numbers in the input' do
+        expect{ calc.add("1, -2, -3, 4") }.to raise_error("Negatives not allowed: -2, -3")
+    end
 end


### PR DESCRIPTION
## 📝 Description

This PR adds a negative number check which raises an exception if the input contains negative number.


## ✅ Changes
Input: "1, -2, -3, 4"
Output:  "Negatives not allowed: -2, -3" error raised


## 🧪 Testing
`rspec string_calculator_spec.rb`
```
Finished in 0.00909 seconds (files took 0.08308 seconds to load)
8 examples, 0 failures

```
## 📸 Screenshots (if applicable)
