### PR TITLE
Add check for numbers greater than 1000

### DIFF
--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -20,7 +20,8 @@ class StringCalculator
         end
         # convert the array of delimiters into regex
         regex = Regexp.union(delimiters)
-        nums = numbers.split(regex).map(&:to_i)
+        # ignore the numbers greater than 1000
+        nums = numbers.split(regex).map(&:to_i).select { |n| n <= 1000 }
 
         negatives = nums.select { |n| n < 0 }
         # raise error if there are negative numbers 

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -34,4 +34,8 @@ describe StringCalculator do
     it 'raises an error if there are negatives numbers in the input' do
         expect{ calc.add("1, -2, -3, 4") }.to raise_error("Negatives not allowed: -2, -3")
     end
+
+    it 'ignores numbers greater than 1000' do
+        expect(calc.add("1,2,1234")).to eq(3)
+    end
 end


### PR DESCRIPTION
## 📝 Description
This PR extends the string calculator functionality wherein a number greater than 1000 in the input will be ignored.

## ✅ Changes
Input: "2, 1001"
Output: 2


## 🧪 Testing
`rspec string_calculator_spec.rb`
```
Finished in 0.00919 seconds (files took 0.08423 seconds to load)
9 examples, 0 failures

```
## 📸 Screenshots (if applicable)
